### PR TITLE
feat: 添加C库mock的方式单元测试

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Packages Builder <packages@deepin.com>
 Build-Depends:
  debhelper-compat (= 12),
  cmake,
+ librsvg2-dev,
  qtbase5-dev
 Standards-Version: 4.5.0
 

--- a/include/demo.h
+++ b/include/demo.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "namespace.h"
+#include <QSize>
 #include <qobject.h>
 
 DDEMO_BEGIN_NAMESPACE
@@ -14,5 +15,8 @@ class Demo : public QObject {
     Demo(QObject *parent = nullptr);
     ~Demo();
     int add(const int a, const int b);
+
+    // librsvg
+    bool svg2png(const QString &svgfile, const QString &pngfile, QSize size = QSize(128, 128));
 };
 DDEMO_END_NAMESPACE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,14 +23,21 @@ set_target_properties(${BIN_NAME} PROPERTIES
 
 target_compile_definitions(${BIN_NAME} PRIVATE VERSION="${CMAKE_PROJECT_VERSION}")
 
+find_package(PkgConfig REQUIRED)
+pkg_search_module(RSVG2 REQUIRED librsvg-2.0)
+
 target_include_directories(${BIN_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::DBus
+    ${RSVG2_INCLUDE_DIRS}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::DBus
+    ${RSVG2_LIBRARIES}
 )
 
 install(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${BIN_NAME})

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <librsvg/rsvg.h>
+
 #include "demo.h"
+
+#include <QtGui/QImage>
+#include <QtGui/QPainter>
+#include <QDebug>
 
 DDEMO_BEGIN_NAMESPACE
 Demo::Demo(QObject *parent) : QObject(parent) {}
@@ -10,5 +16,44 @@ Demo::Demo(QObject *parent) : QObject(parent) {}
 Demo::~Demo() {}
 
 int Demo::add(const int a, const int b) { return a + b; }
+
+bool Demo::svg2png(const QString &svgfile, const QString &pngfile,  QSize size)
+{
+    QImage outPutimage(size, QImage::Format_ARGB32);
+    outPutimage.fill(Qt::transparent);
+    QPainter outputPainter(&outPutimage);
+
+    // librsvg
+    {
+        GError *error = nullptr;
+        RsvgHandle *handle = rsvg_handle_new_from_file(svgfile.toUtf8().data(), &error);
+        if (error) {
+            qWarning("DSvgRenderer::load: %s", error->message);
+            g_error_free(error);
+            return false;
+        }
+
+        RsvgDimensionData rsvg_data;
+
+        rsvg_handle_get_dimensions(handle, &rsvg_data);
+
+        QSizeF defaultSize(rsvg_data.width, rsvg_data.height);
+        QRectF viewBox(QPointF(0, 0), defaultSize);
+
+        cairo_surface_t *surface = cairo_image_surface_create_for_data(
+                    outPutimage.bits(), CAIRO_FORMAT_ARGB32,
+                    outPutimage.width(), outPutimage.height(), outPutimage.bytesPerLine());
+        cairo_t *cairo = cairo_create(surface);
+        cairo_scale(cairo, outPutimage.width() / viewBox.width(), outPutimage.height() / viewBox.height());
+        cairo_translate(cairo, -viewBox.x(), -viewBox.y());
+        rsvg_handle_render_cairo(handle, cairo);
+
+        cairo_destroy(cairo);
+        cairo_surface_destroy(surface);
+        g_object_unref(handle);
+    }
+
+    return outPutimage.save(pngfile);
+}
 
 DDEMO_END_NAMESPACE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(BIN_NAME ut-dtkdemo)
 
-add_definitions(-DUSE_MOCK_INTERFACE)
+#add_definitions(-DUSE_MOCK_INTERFACE)
 
 include(./dbus/fakeInterface.cmake)
 
@@ -27,18 +27,25 @@ add_executable(${BIN_NAME}
     ${DFAKE_INTERFACE_DBUS_XML}
 )
 
+find_package(PkgConfig REQUIRED)
+pkg_search_module(RSVG2 REQUIRED librsvg-2.0)
+
 target_include_directories(${BIN_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::DBus
+    ${RSVG2_INCLUDE_DIRS}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::DBus
+    ${RSVG2_LIBRARIES}
     -lpthread
     -lgcov
     -lgtest
-    -ldl            # dlsym
+    -Wl,--wrap=g_object_unref    # --wrap=symbol replace g_object_unref
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/tests/libdemo/libmockdemo.cpp
+++ b/tests/libdemo/libmockdemo.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <librsvg/rsvg.h>
+#include <QDebug>
+
+extern "C"{
+
+////// mock rsvg_handle_new_from_file
+RsvgHandle *rsvg_handle_new_from_file (const gchar *file_name, GError **error)
+{
+    Q_UNUSED(file_name);
+    Q_UNUSED(error);
+    qInfo() << __func__ << "mocked";
+   // magic ptr...烫烫烫
+   return reinterpret_cast<RsvgHandle *>(0xcccc);
+}
+
+////// mock rsvg_handle_get_dimensions
+void rsvg_handle_get_dimensions (RsvgHandle *handle, RsvgDimensionData *dimension_data)
+{
+    Q_UNUSED(handle);
+    Q_UNUSED(dimension_data);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+//// mock cairo_image_surface_create_for_data
+cairo_surface_t *cairo_image_surface_create_for_data(unsigned char *data,
+          cairo_format_t format, int width, int height, int stride)
+{
+    Q_UNUSED(data);
+    Q_UNUSED(format);
+    Q_UNUSED(width);
+    Q_UNUSED(height);
+    Q_UNUSED(stride);
+    qInfo() << __func__ << "mocked";
+
+   return reinterpret_cast<cairo_surface_t *>(0xcccc); // magic ptr...烫烫烫
+}
+
+//// mock cairo_create
+cairo_t *cairo_create (cairo_surface_t *target)
+{
+    Q_UNUSED(target);
+    qInfo() << __func__ << "mocked";
+
+   return reinterpret_cast<cairo_t *>(0xcccc);// magic ptr...烫烫烫
+}
+
+//// mock cairo_scale
+void cairo_scale(cairo_t *cr, double sx, double sy)
+{
+    Q_UNUSED(cr);
+    Q_UNUSED(sx);
+    Q_UNUSED(sy);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+//// mock cairo_translate
+void cairo_translate(cairo_t *cr, double tx, double ty)
+{
+    Q_UNUSED(cr);
+    Q_UNUSED(tx);
+    Q_UNUSED(ty);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+//// mock rsvg_handle_render_cairo
+gboolean rsvg_handle_render_cairo (RsvgHandle *handle, cairo_t *cr)
+{
+    Q_UNUSED(handle);
+    Q_UNUSED(cr);
+    qInfo() << __func__ << "mocked";
+    return true;
+}
+
+//// mock cairo_surface_destroy
+void cairo_surface_destroy(cairo_surface_t *surface)
+{
+    Q_UNUSED(surface);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+//// mock cairo_destroy
+void cairo_destroy(cairo_t *cr)
+{
+    Q_UNUSED(cr);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+//// mock g_object_unref
+/* ld --wrap=symbol
+*  Use a wrapper function for symbol.  Any undefined reference to
+*  symbol will be resolved to "__wrap_symbol".  Any undefined
+*  reference to "__real_symbol" will be resolved to symbol.
+*  call __real_g_object_unref for real g_object_unref function
+*/
+void __wrap_g_object_unref (gpointer object)
+{
+    Q_UNUSED(object);
+    qInfo() << __func__ << "mocked";
+    return;
+}
+
+}

--- a/tests/ut-demo.cpp
+++ b/tests/ut-demo.cpp
@@ -27,3 +27,9 @@ TEST_F(ut_Demo, add)
 {
     EXPECT_EQ(3, m_demo->add(1, 2));
 }
+
+TEST_F(ut_Demo, svg2png)
+{
+    EXPECT_TRUE(m_demo->svg2png("/no/exist/svg", "/tmp/test.png"));
+}
+


### PR DESCRIPTION
通过覆盖实现的方式mock原来的接口，
单元测试时通过宏控制开关走覆盖接口

Log: