### PR TITLE
fix: invalid version for cmake

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,13 @@
 include /usr/share/dpkg/default.mk
 export QT_SELECT = qt5
 
+PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
+# Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
+BUILD_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
+
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION=$(DEB_VERSION_UPSTREAM)
+	dh_auto_configure -- -DBUILD_VERSION=$(BUILD_VER) -DVERSION=$(PACK_VER)
 


### PR DESCRIPTION
Log: 处理类似 1.0.0+u001 这种不适合直接传给 cmake 的 deb 版本号

方法摘抄自 dtkcore