### PR TITLE
fix: fix doc existence error

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,8 @@ Build-Depends:
  debhelper-compat (= 12),
  cmake,
  librsvg2-dev,
- qtbase5-dev
+ qtbase5-dev,
+ doxygen <!nodoc>
 Standards-Version: 4.5.0
 
 Package: libdtkdemo
@@ -19,8 +20,18 @@ Description: Deepin Tool Kit template library
 
 Package: libdtkdemo-dev
 Architecture: any
-Depends:${misc:Depends}, libdtktemplate( =${binary:Version})
+Depends:${misc:Depends}, libdtkdemo( =${binary:Version})
 Description: Deepin Tool Kit template devel library
  libdtkdemo-dev is base devel library of Deepin Qt/C++ applications.
  .
  This package contains the header files and static libraries.
+
+Package: libdtkdemo-doc
+Architecture: any
+Build-Profiles: <!nodoc>
+Depends:${misc:Depends}, libdtkdemo-dev( =${binary:Version})
+Description: Deepin Tool Kit template devel library
+ libdtkdemo-doc is base devel document of Deepin Qt/C++ applications.
+ .
+ This package contains the devel documents.
+

--- a/debian/libdtkdemo-dev.install
+++ b/debian/libdtkdemo-dev.install
@@ -3,4 +3,3 @@ usr/include
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*/*.cmake
 usr/lib/*/*/mkspecs/modules/*.pri
-usr/share/*/doc/*.qch

--- a/debian/libdtkdemo-doc.install
+++ b/debian/libdtkdemo-doc.install
@@ -1,0 +1,1 @@
+usr/share/*/doc/*.qch


### PR DESCRIPTION
It will be an error to check for documentation existence when no doc is generated. Add nodoc DEB_BUILD_PROFILES to generate doc or not.

Log: